### PR TITLE
Pin shapely dependency to lower than version 2.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ rasterio
 requests
 rio-cogeo
 rtree
-shapely
+shapely<2
 scikit-learn
 tensorflow
 tensorflow-addons


### PR DESCRIPTION
This is a workaround for an issue in the google aiplatform library:

https://github.com/googleapis/python-aiplatform/issues/1852