### PR TITLE
Adding string_label feature to tensorflow examples | Adding option to…

### DIFF
--- a/src/create_labeled_dataset.py
+++ b/src/create_labeled_dataset.py
@@ -50,7 +50,7 @@ flags.DEFINE_list(
         'major_damage=1',
         'destroyed=1',
     ],
-    'List of "class=label" strings, e.g. "no_damaged=0,minor_damage=0,...".',
+    'List of "class=label" strings, e.g. "no_damage=0,minor_damage=0,...".',
 )
 
 

--- a/src/create_labeled_dataset.py
+++ b/src/create_labeled_dataset.py
@@ -45,12 +45,12 @@ flags.DEFINE_list(
     'string_to_numeric_labels',
     [
         'bad_example=0',
-        'undamaged=0',
+        'no_damage=0',
         'minor_damage=1',
         'major_damage=1',
         'destroyed=1',
     ],
-    'List of "class=label" strings, e.g. "undamaged=0,minor_damage=0,...".',
+    'List of "class=label" strings, e.g. "no_damaged=0,minor_damage=0,...".',
 )
 
 

--- a/src/generate_examples_main.py
+++ b/src/generate_examples_main.py
@@ -149,7 +149,7 @@ flags.DEFINE_string(
     'labels_file', None, 'If specified, read labels for dataset from this file.'
 )
 flags.DEFINE_string(
-    'label_property', None, 'Property to use as label, e.g. "Main_Damag".'
+    'label_property', None, 'Property to use as label, e.g. "string_label".'
 )
 flags.DEFINE_list(
     'labels_to_classes',

--- a/src/run_tests.sh
+++ b/src/run_tests.sh
@@ -27,9 +27,16 @@ else
 fi
 
 function setup {
-  which python
-  python --version
-  python -m venv "${VIRTUALENV_PATH}"
+  if ! which python && which python3
+  then
+    PYTHON=python3
+  else
+    PYTHON=python
+  fi
+
+  which $PYTHON
+  $PYTHON --version
+  $PYTHON -m venv "${VIRTUALENV_PATH}"
   source "${VIRTUALENV_PATH}/bin/activate"
   pushd "${SKAI_DIR}"
   which pip

--- a/src/skai/cloud_labeling_test.py
+++ b/src/skai/cloud_labeling_test.py
@@ -117,7 +117,7 @@ class CloudLabelingTest(absltest.TestCase):
         test_fraction=0.333,
         train_output_path=train_path,
         test_output_path=test_path,
-    )
+        use_multiprocessing=False)
 
     all_examples = _read_tfrecord(train_path) + _read_tfrecord(test_path)
     self.assertLen(all_examples, 6)

--- a/src/skai/cloud_labeling_test.py
+++ b/src/skai/cloud_labeling_test.py
@@ -28,7 +28,7 @@ class CloudLabelingTest(absltest.TestCase):
     before_image = PIL.Image.new('RGB', (64, 64))
     after_image = PIL.Image.new('RGB', (64, 64))
     labeling_image = cloud_labeling.create_labeling_image(
-        before_image, after_image)
+        before_image, after_image, 'example_id', 'plus_code')
     self.assertEqual(labeling_image.width, 158)
     self.assertEqual(labeling_image.height, 116)
 

--- a/src/skai/generate_examples.py
+++ b/src/skai/generate_examples.py
@@ -812,7 +812,7 @@ def generate_examples_pipeline(before_image_patterns: List[str],
         os.path.join(output_dir, 'examples', 'unlabeled', 'unlabeled'))
     large_examples_output_prefix = (
         os.path.join(output_dir, 'examples', 'unlabeled-large', 'unlabeled'))
-    labeled_coordinates = [(longitude, latitude, -1.0, 'no_label')
+    labeled_coordinates = [(longitude, latitude, -1.0, '')
                            for longitude, latitude in unlabeled_coordinates]
     utils.write_coordinates_file(labeled_coordinates, coordinates_path)
 

--- a/src/skai/generate_examples.py
+++ b/src/skai/generate_examples.py
@@ -538,7 +538,7 @@ def _coordinates_to_scalar_features(coordinates_path: str):
     feature = _FeatureUnion(scalar_features={
         'coordinates': [longitude, latitude],
         'label': [label],
-        'string_label' : string_label
+        'string_label' : [string_label]
     })
     yield (encoded_coords, feature)
 

--- a/src/skai/generate_examples.py
+++ b/src/skai/generate_examples.py
@@ -95,7 +95,7 @@ class ExamplesGenerationConfig:
   labels_file: Optional[str] = None
   label_property: Optional[str] = None
   labels_to_classes: Optional[List[str]] = None
-  num_keep_labeled_examples: int = 1000
+  num_keep_labeled_examples: int = None
   configuration_path: Optional[str] = None
 
   # TODO(mohammedelfatihsalah): Add a type for flagvalues argument in init_from_flags.

--- a/src/skai/generate_examples.py
+++ b/src/skai/generate_examples.py
@@ -21,7 +21,7 @@ import logging
 import os
 import pathlib
 import pickle
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple,Union
 
 import apache_beam as beam
 import cv2
@@ -374,7 +374,7 @@ class GenerateExamplesFn(beam.DoFn):
       before_image: np.ndarray,
       after_image_id: str,
       after_image: np.ndarray,
-      scalar_features: Dict[str, Any]) -> Optional[Example]:
+      scalar_features: Dict[str, List[Union[float, str]]]) -> Optional[Example]:
     """Create Tensorflow Example from inputs.
 
     Args:
@@ -426,8 +426,8 @@ class GenerateExamplesFn(beam.DoFn):
                             tf.io.encode_png(after_crop).numpy(), example)
     utils.add_bytes_feature('post_image_id', after_image_id.encode(), example)
     for name, value in scalar_features.items():
-      if isinstance(value, str):
-        utils.add_bytes_feature(name,value.encode(), example)
+      if all(isinstance(v, str) for v in value):
+        utils.add_bytes_list_feature(name,[v.encode() for v in value], example)
       else:
         utils.add_float_list_feature(name, value, example)
     return example

--- a/src/skai/generate_examples.py
+++ b/src/skai/generate_examples.py
@@ -22,7 +22,7 @@ import logging
 import os
 import pathlib
 import pickle
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple,Union
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
 import apache_beam as beam
 import cv2
@@ -539,7 +539,7 @@ def _coordinates_to_scalar_features(coordinates_path: str):
     feature = _FeatureUnion(scalar_features={
         'coordinates': [longitude, latitude],
         'label': [label],
-        'string_label' : [string_label]
+        'string_label': [string_label]
     })
     yield (encoded_coords, feature)
 
@@ -780,8 +780,8 @@ def generate_examples_pipeline(before_image_patterns: List[str],
     num_output_shards: Number of output shards.
     unlabeled_coordinates: List of coordinates (longitude, latitude) to extract
       unlabeled examples for.
-    labeled_coordinates: List of coordinates (longitude, latitude, label, string_label) to
-      extract labeled examples for.
+    labeled_coordinates: List of coordinates (longitude, latitude, label,
+      string_label) to extract labeled examples for.
     use_dataflow: If true, run pipeline on GCP Dataflow.
     gdal_env: GDAL environment configuration.
     dataflow_job_name: Name of dataflow job.

--- a/src/skai/generate_examples_test.py
+++ b/src/skai/generate_examples_test.py
@@ -63,6 +63,7 @@ def _check_examples(
     small_patch_size: int,
     large_patch_size: int,
     expected_coordinates: List[Tuple[float, float, float]],
+    expected_string_labels: List[str],
     expected_plus_codes: List[str],
     expect_blank_before: bool,
     expect_large_patch: bool,
@@ -85,6 +86,7 @@ def _check_examples(
 
   def _check_examples_internal(actual_examples):
     actual_coordinates = set()
+    actual_string_labels = []
     actual_plus_codes = []
     expected_small_shape = (small_patch_size, small_patch_size, 3)
     expected_large_shape = (large_patch_size, large_patch_size, 3)
@@ -162,12 +164,14 @@ def _check_examples(
             f'actual = {large_after_image.shape}')
 
       actual_coordinates.add((longitude, latitude, label))
+      actual_string_labels.append(
+          example.features.feature['string_label'].bytes_list.value[0].decode())
       actual_plus_codes.append(
           example.features.feature['plus_code'].bytes_list.value[0].decode()
       )
 
     assert _unordered_all_close(expected_coordinates, actual_coordinates)
-
+    assert set(expected_string_labels) == set(actual_string_labels)
     assert len(expected_plus_codes) == len(actual_plus_codes)
 
     expected_plus_codes_sorted = sorted(expected_plus_codes)
@@ -217,7 +221,8 @@ class GenerateExamplesTest(absltest.TestCase):
               self.test_image_path,
               32,
               62,
-              [(178.482925, -16.632893, -1.0, '')],
+              [(178.482925, -16.632893, -1.0)],
+              [''],
               ['5VMW9F8M+R5V8F4'],
               False,
               True,
@@ -231,7 +236,8 @@ class GenerateExamplesTest(absltest.TestCase):
               self.test_image_path,
               32,
               62,
-              [(178.482925, -16.632893, -1.0, '')],
+              [(178.482925, -16.632893, -1.0)],
+              [''],
               ['5VMW9F8M+R5V8F4'],
               False,
               False,
@@ -258,7 +264,8 @@ class GenerateExamplesTest(absltest.TestCase):
               self.test_image_path,
               32,
               62,
-              [(178.482925, -16.632893, 0.0, 'no_damage'), (178.482924, -16.632894, 1.0, 'destroyed')],
+              [(178.482925, -16.632893, 0.0), (178.482924, -16.632894, 1.0)],
+              ['no_damage', 'destroyed'],
               ['5VMW9F8M+R5V8F4', '5VMW9F8M+R5V872'],
               False,
               True,
@@ -273,7 +280,8 @@ class GenerateExamplesTest(absltest.TestCase):
               self.test_image_path,
               32,
               62,
-              [(178.482925, -16.632893, 0.0, 'no_damage'), (178.482924, -16.632894, 1.0, 'destroyed')],
+              [(178.482925, -16.632893, 0.0), (178.482924, -16.632894, 1.0)],
+              ['no_damage', 'destroyed'],
               ['5VMW9F8M+R5V8F4', '5VMW9F8M+R5V872'],
               False,
               False,
@@ -302,7 +310,8 @@ class GenerateExamplesTest(absltest.TestCase):
               self.test_image_path,
               32,
               62,
-              [(178.482925, -16.632893, -1.0, '')],
+              [(178.482925, -16.632893, -1.0)],
+              [''],
               ['5VMW9F8M+R5V8F4'],
               True,
               True,
@@ -317,7 +326,8 @@ class GenerateExamplesTest(absltest.TestCase):
               self.test_image_path,
               32,
               62,
-              [(178.482925, -16.632893, -1.0, '')],
+              [(178.482925, -16.632893, -1.0)],
+              [''],
               ['5VMW9F8M+R5V8F4'],
               True,
               False,
@@ -421,7 +431,7 @@ class GenerateExamplesTest(absltest.TestCase):
     self.assertIsNone(config.labels_file)
     self.assertIsNone(config.label_property)
     self.assertIsNone(config.labels_to_classes)
-    self.assertEqual(config.num_keep_labeled_examples, 1000)
+    self.assertIsNone(config.num_keep_labeled_examples)
     self.assertIsNone(config.configuration_path)
 
   def testConfigRaiseErrorOnMissingDatasetName(self):

--- a/src/skai/generate_examples_test.py
+++ b/src/skai/generate_examples_test.py
@@ -67,8 +67,7 @@ def _check_examples(
     expected_string_labels: List[str],
     expected_plus_codes: List[str],
     expect_blank_before: bool,
-    expect_large_patch: bool,
-):
+    expect_large_patch: bool):
   """Validates examples generated from beam pipeline.
 
   Args:
@@ -77,6 +76,7 @@ def _check_examples(
     small_patch_size: The expected size of small patches.
     large_patch_size: The expected size of large patches.
     expected_coordinates: List of coordinates that examples should have.
+    expected_string_labels: List of string labels that examples should have.
     expected_plus_codes: List of plus codes that examples should have.
     expect_blank_before: If true, the before image should be all zeros.
     expect_large_patch: If true, the examples should contain large patches.

--- a/src/skai/generate_examples_test.py
+++ b/src/skai/generate_examples_test.py
@@ -102,6 +102,7 @@ def _check_examples(
           'label',
           'example_id',
           'plus_code',
+          'string_label'
       ])
       if expect_large_patch:
         expected_feature_names.update(
@@ -198,8 +199,8 @@ class GenerateExamplesTest(absltest.TestCase):
   def testGenerateExamplesFn(self):
     """Tests GenerateExamplesFn class."""
 
-    unlabeled_coordinates = [(178.482925, -16.632893, -1.0),
-                             (178.482283, -16.632279, -1.0)]
+    unlabeled_coordinates = [(178.482925, -16.632893, -1.0, ''),
+                             (178.482283, -16.632279, -1.0, '')]
     utils.write_coordinates_file(unlabeled_coordinates, self.coordinates_path)
 
     with test_pipeline.TestPipeline() as pipeline:
@@ -216,7 +217,7 @@ class GenerateExamplesTest(absltest.TestCase):
               self.test_image_path,
               32,
               62,
-              [(178.482925, -16.632893, -1.0)],
+              [(178.482925, -16.632893, -1.0, '')],
               ['5VMW9F8M+R5V8F4'],
               False,
               True,
@@ -230,7 +231,7 @@ class GenerateExamplesTest(absltest.TestCase):
               self.test_image_path,
               32,
               62,
-              [(178.482925, -16.632893, -1.0)],
+              [(178.482925, -16.632893, -1.0, '')],
               ['5VMW9F8M+R5V8F4'],
               False,
               False,
@@ -241,8 +242,8 @@ class GenerateExamplesTest(absltest.TestCase):
   def testGenerateExamplesFnLabeled(self):
     """Tests GenerateExamplesFn class."""
 
-    labeled_coordinates = [(178.482925, -16.632893, 0),
-                           (178.482924, -16.632894, 1)]
+    labeled_coordinates = [(178.482925, -16.632893, 0, 'no_damage'),
+                           (178.482924, -16.632894, 1, 'destroyed')]
     utils.write_coordinates_file(labeled_coordinates, self.coordinates_path)
 
     with test_pipeline.TestPipeline() as pipeline:
@@ -257,7 +258,7 @@ class GenerateExamplesTest(absltest.TestCase):
               self.test_image_path,
               32,
               62,
-              [(178.482925, -16.632893, 0.0), (178.482924, -16.632894, 1.0)],
+              [(178.482925, -16.632893, 0.0, 'no_damage'), (178.482924, -16.632894, 1.0, 'destroyed')],
               ['5VMW9F8M+R5V8F4', '5VMW9F8M+R5V872'],
               False,
               True,
@@ -272,7 +273,7 @@ class GenerateExamplesTest(absltest.TestCase):
               self.test_image_path,
               32,
               62,
-              [(178.482925, -16.632893, 0.0), (178.482924, -16.632894, 1.0)],
+              [(178.482925, -16.632893, 0.0, 'no_damage'), (178.482924, -16.632894, 1.0, 'destroyed')],
               ['5VMW9F8M+R5V8F4', '5VMW9F8M+R5V872'],
               False,
               False,
@@ -283,8 +284,8 @@ class GenerateExamplesTest(absltest.TestCase):
   def testGenerateExamplesFnNoBefore(self):
     """Tests GenerateExamplesFn class without before image."""
 
-    coordinates = [(178.482925, -16.632893, -1.0),
-                   (178.482283, -16.632279, -1.0)]
+    coordinates = [(178.482925, -16.632893, -1.0, ''),
+                   (178.482283, -16.632279, -1.0, '')]
     utils.write_coordinates_file(coordinates, self.coordinates_path)
 
     with test_pipeline.TestPipeline() as pipeline:
@@ -301,7 +302,7 @@ class GenerateExamplesTest(absltest.TestCase):
               self.test_image_path,
               32,
               62,
-              [(178.482925, -16.632893, -1.0)],
+              [(178.482925, -16.632893, -1.0, '')],
               ['5VMW9F8M+R5V8F4'],
               True,
               True,
@@ -316,7 +317,7 @@ class GenerateExamplesTest(absltest.TestCase):
               self.test_image_path,
               32,
               62,
-              [(178.482925, -16.632893, -1.0)],
+              [(178.482925, -16.632893, -1.0, '')],
               ['5VMW9F8M+R5V8F4'],
               True,
               False,
@@ -326,7 +327,7 @@ class GenerateExamplesTest(absltest.TestCase):
 
   def testGenerateExampleFnPathPattern(self):
     """Test GenerateExampleFn class with a path pattern."""
-    coordinates = [(178.482925, -16.632893, -1.0)]
+    coordinates = [(178.482925, -16.632893, -1.0, '')]
     utils.write_coordinates_file(coordinates, self.coordinates_path)
 
     expected_before_image_ids = glob.glob(self.test_image_path_patterns)

--- a/src/skai/read_raster.py
+++ b/src/skai/read_raster.py
@@ -263,7 +263,7 @@ def _coordinates_to_groups(
   coordinates = utils.read_coordinates_file(coordinates_path)
   coords_with_ids = [(utils.encode_coordinates(longitude,
                                                latitude), longitude, latitude)
-                     for longitude, latitude, _ in coordinates]
+                     for longitude, latitude, _, _ in coordinates]
   with rasterio.Env(**gdal_env):
     raster = rasterio.open(raster_path)
     raster_res = _get_raster_resolution_in_meters(raster)

--- a/src/skai/read_raster_test.py
+++ b/src/skai/read_raster_test.py
@@ -101,9 +101,9 @@ class ReadRasterTest(absltest.TestCase):
 
   def test_coordinates_to_groups(self):
     coordinates = [
-        (178.482925, -16.632893, -1.0),
-        (178.482283, -16.632279, -1.0),
-        (178.482284, -16.632279, -1.0)]
+        (178.482925, -16.632893, -1.0, 'no_damage'),
+        (178.482283, -16.632279, -1.0, 'no_damage'),
+        (178.482284, -16.632279, -1.0, 'no_damage')]
 
     with tempfile.NamedTemporaryFile(dir=absltest.TEST_TMPDIR.value) as f:
       coordinates_path = f.name

--- a/src/skai/utils.py
+++ b/src/skai/utils.py
@@ -69,6 +69,13 @@ def add_float_list_feature(feature_name: str,
   example.features.feature[feature_name].float_list.value.extend(value)
 
 
+def add_bytes_list_feature(feature_name: str,
+                           value: Iterable[bytes],
+                           example: Example) -> None:
+  """Add bytes list feature to tensorflow Example."""
+  example.features.feature[feature_name].bytes_list.value.extend(value)
+
+
 def add_bytes_feature(feature_name: str,
                       value: bytes,
                       example: Example) -> None:


### PR DESCRIPTION
… filter out labels from labeling task to create labeled dataset | Correcting string_to_numeric_labels default values

If labels_file is provided, the string_label feature is equal to the string_property value in labeled tensorflow examples. If not, the string_label feature is equal to the value "no_label" in unlabeled tensorflow examples.

We exclude on-purpose labels that are not included in the string_to_numeric_labels flag to enable to user to explicitly include/exclude labels to create the labeled dataset.

Change "undamaged" default value to "no_damage" (consistency between create_labeling_task.py and create_labeled_dataset.py)